### PR TITLE
Improve compatibility with requirejs

### DIFF
--- a/src/Hydra.js
+++ b/src/Hydra.js
@@ -988,15 +988,15 @@
     FakeModule.prototype = {
         start: function(oData)
         {
-            return Module.prototype.start(this.sModuleId, undefined, oData);
+            Hydra.module.start(this.sModuleId, oData);
         },
         extend: function(oSecondParameter, oThirdParameter)
         {
-            return Module.prototype.extend(this.sModuleId, oSecondParameter, oThirdParameter);
+            return Hydra.module..extend(this.sModuleId, oSecondParameter, oThirdParameter);
         },
-        stop: function()
+        stop: function(sInstanceId)
         {
-            Module.prototype.stop(this.sModuleId);
+            Hydra.module.stop(this.sModuleId, sInstanceId);
         }
     };
 

--- a/src/Hydra.js
+++ b/src/Hydra.js
@@ -986,9 +986,9 @@
     };
 
     FakeModule.prototype = {
-        start: function(oData)
+        start: function(sIdInstance, oData)
         {
-            Hydra.module.start(this.sModuleId, oData);
+            Hydra.module.start(this.sModuleId, sIdInstance, oData);
         },
         extend: function(oSecondParameter, oThirdParameter)
         {

--- a/src/Hydra.js
+++ b/src/Hydra.js
@@ -992,7 +992,7 @@
         },
         extend: function(oSecondParameter, oThirdParameter)
         {
-            return Hydra.module..extend(this.sModuleId, oSecondParameter, oThirdParameter);
+            return Hydra.module.extend(this.sModuleId, oSecondParameter, oThirdParameter);
         },
         stop: function(sInstanceId)
         {


### PR DESCRIPTION
Since now it wasn't possible to start a module using the FakeModule and passing some data to the init method. It wasn't possible as well to stop some specific instance of the module using the stop method of the FakeModule.

I had problems when testing if a module was started using the FakeModule and I think it could be easily solved by using Hydra.module instead of Module.prototype
