### PR TITLE
Data was being lost on FakeModule starts.

### DIFF
--- a/src/Hydra.js
+++ b/src/Hydra.js
@@ -1276,7 +1276,7 @@
 	FakeModule.prototype = {
 		start: function ( oData )
 		{
-			Hydra.module.start( this.sModuleId, undefined, oData );
+			Hydra.module.start( this.sModuleId, oData );
 			return this;
 		},
 		extend: function ( oSecondParameter, oThirdParameter )


### PR DESCRIPTION
Object data passed to a FakeModule was being lost in the Hydra.module.start call due to a wrong parameter call.
